### PR TITLE
Fix evaluate changes infinite loop due to None

### DIFF
--- a/Evaluate-ModelarDB-Changes/main.py
+++ b/Evaluate-ModelarDB-Changes/main.py
@@ -155,8 +155,9 @@ def send_sigint_to_process(process):
     process.send_signal(signal.SIGINT)
 
     # Ensure process is fully shutdown.
-    while process.poll():
+    while process.poll() is None:
         time.sleep(10)
+
     process.wait()
 
 


### PR DESCRIPTION
This PR fixes an infinite loop in the evaluate changes script caused by a misunderstanding that [`Popen.poll()`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.poll) returns `None` while the process is still running and not when it has terminated.