### PR TITLE
Add --all-targets to cargo build, clippy, and test

### DIFF
--- a/Git-Hooks/rust-pre-commit
+++ b/Git-Hooks/rust-pre-commit
@@ -9,10 +9,10 @@ set -e
 # machette), the documentation generator (cargo doc), and the unit tests and
 # integration tests (cargo test) does not emit any errors or warnings at all.
 echo "Cargo Build"
-RUSTFLAGS="-D warnings" cargo build
+RUSTFLAGS="-D warnings" cargo build --all-targets
 echo
 echo "Cargo Clippy"
-RUSTFLAGS="-D warnings" cargo clippy
+RUSTFLAGS="-D warnings" cargo clippy --all-targets
 echo
 echo "Cargo Doc"
 RUSTDOCFLAGS="-D warnings" cargo doc
@@ -21,4 +21,4 @@ echo "Cargo Machette"
 cargo machete --with-metadata
 echo
 echo "Cargo Test"
-RUSTFLAGS="-D warnings" cargo test
+RUSTFLAGS="-D warnings" cargo test --all-targets


### PR DESCRIPTION
This PR add --all-targets to cargo build, clippy, and test to ensure the commands are run for all targets in rust-pre-commit to match changes to [ModelarDB-RS GitHub Actions in PR #67](https://github.com/ModelarData/ModelarDB-RS/pull/67).