### PR TITLE
Add --nocapture to cargo test to print the seed

### DIFF
--- a/Git-Hooks/rust-pre-commit
+++ b/Git-Hooks/rust-pre-commit
@@ -24,7 +24,7 @@ echo "Cargo Machette"
 cargo machete --with-metadata
 echo
 echo "Cargo Test"
-RUSTFLAGS="-D warnings" cargo test --all-targets
+RUSTFLAGS="-D warnings" cargo test --all-targets -- --nocapture
 echo
 echo "Python Build"
 cd crates/modelardb_compression_python


### PR DESCRIPTION
This PR make pre-commit not capture the output of `cargo test` so the seed added by ModelarData/ModelarDB-RS#109 can be read from the output and the automatically generated test data reproduced.