### PR TITLE
Reduce sleep to match modelardb_server's tests

### DIFF
--- a/Evaluate-ModelarDB-Changes/main.py
+++ b/Evaluate-ModelarDB-Changes/main.py
@@ -90,7 +90,7 @@ def start_modelardbd(modelardb_folder, data_folder):
 
     # Ensure process is fully started.
     while not b"Starting Apache Arrow Flight on" in process.stdout.readline():
-        time.sleep(10)
+        time.sleep(1)
 
     return process
 
@@ -146,7 +146,7 @@ def send_sigint_to_process(process):
 
     # Ensure process is fully shutdown.
     while process.poll() is None:
-        time.sleep(10)
+        time.sleep(1)
 
     process.wait()
 

--- a/Evaluate-ModelarDB-Compression/main.py
+++ b/Evaluate-ModelarDB-Compression/main.py
@@ -51,7 +51,7 @@ def start_modelardbd(modelardb_folder, data_folder):
 
     # Ensure process is fully started.
     while not b"Starting Apache Arrow Flight on" in process.stdout.readline():
-        time.sleep(10)
+        time.sleep(1)
 
     return process
 
@@ -251,7 +251,7 @@ def send_sigint_to_process(process):
 
     # Ensure process is fully shutdown.
     while process.poll() is None:
-        time.sleep(10)
+        time.sleep(1)
 
     process.wait()
 


### PR DESCRIPTION
This PR reduces the amount of seconds passed to `time.sleep` to match `modelardb_server`'s integration tests