### PR TITLE
Cast timestamps in Apache Parquet Loader

### DIFF
--- a/Apache-Parquet-Loader/main.py
+++ b/Apache-Parquet-Loader/main.py
@@ -44,9 +44,16 @@ def read_parquet_file_or_folder(path):
         safe_name = field.name.replace(" ", "_")
         column_names.append(safe_name)
 
-        # Ensure all fields are float32 as float64 are not supported.
-        if field.type == pyarrow.float64():
+        if field.type == pyarrow.float16() or field.type == pyarrow.float64():
+            # Ensure fields are float32 as others are not supported.
             columns.append((safe_name, pyarrow.float32()))
+        elif field.type in [
+            pyarrow.timestamp("s"),
+            pyarrow.timestamp("us"),
+            pyarrow.timestamp("ns"),
+        ]:
+            # Ensure timestamps are timestamp[ms] as others are not supported.
+            columns.append((safe_name, pyarrow.timestamp("ms")))
         else:
             columns.append((safe_name, field.type))
 


### PR DESCRIPTION
This PR makes the Apache Parquet Loader cast timestamps to milliseconds as it is the only [unit](https://arrow.apache.org/docs/python/generated/pyarrow.timestamp.html) supported.