### PR TITLE
Ensure query forcing compaction is flushed

### DIFF
--- a/Evaluate-ModelarDB-Changes/main.py
+++ b/Evaluate-ModelarDB-Changes/main.py
@@ -271,6 +271,7 @@ if __name__ == "__main__":
         # Measure compaction time in seconds.
         with tempfile.NamedTemporaryFile("w+") as small_select_query:
             small_select_query.write(f"SELECT * FROM {TABLE_NAME} LIMIT 1")
+            small_select_query.flush()
             compaction_time = execute_queries(small_select_query.name)
             if not compaction_time:
                 print("ERROR: failed to compact files.")


### PR DESCRIPTION
`Evaluate-ModelarDB-Changes` forces `modelardbd` to compact the ingested data points by executing the query `SELECT * FROM evaluate_changes LIMIT 1`. As `Evaluate-ModelarDB-Changes` is designed to execute different query workloads from files to evaluate how changes to `modelardbd` impacts query performance, `SELECT * FROM evaluate_changes LIMIT 1` are written to a file and then executed. However, the file was not guaranteed to be flushed when it as passed to `modelardb` meaning compaction was done as part of the query workload instead of as a separate step.