### PR TITLE
Explicitly use relative error bounds

### DIFF
--- a/Apache-Arrow-Flight-Manager-Tester/main.py
+++ b/Apache-Arrow-Flight-Manager-Tester/main.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
         "CommandStatementUpdate",
         "CREATE MODEL TABLE test_model_table_1(location TAG, install_year TAG, model"
         " TAG, timestamp TIMESTAMP, power_output FIELD, wind_speed FIELD, temperature"
-        " FIELD(5))",
+        " FIELD(5%))",
     ))
 
     print(list_table_names(manager_client))

--- a/Apache-Arrow-Flight-Server-Tester/main.py
+++ b/Apache-Arrow-Flight-Server-Tester/main.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
         "CommandStatementUpdate",
         "CREATE MODEL TABLE test_model_table_1(location TAG, install_year TAG, model"
         " TAG, timestamp TIMESTAMP, power_output FIELD, wind_speed FIELD, temperature"
-        " FIELD(5))",
+        " FIELD(5%))",
     )
 
     list_flights(flight_client)

--- a/Apache-Parquet-Loader/main.py
+++ b/Apache-Parquet-Loader/main.py
@@ -20,7 +20,7 @@ def create_model_table(flight_client, table_name, schema, error_bound):
         if field.type == pyarrow.timestamp("ms"):
             columns.append(f"{field.name} TIMESTAMP")
         elif field.type == pyarrow.float32():
-            columns.append(f"{field.name} FIELD({error_bound})")
+            columns.append(f"{field.name} FIELD({error_bound}%)")
         elif field.type == pyarrow.string():
             columns.append(f"{field.name} TAG")
         else:
@@ -81,7 +81,7 @@ def do_put_arrow_table(flight_client, table_name, arrow_table):
 # Main Function.
 if __name__ == "__main__":
     if len(sys.argv) != 4 and len(sys.argv) != 5:
-        print(f"usage: {sys.argv[0]} host table parquet_file_or_folder [error_bound]")
+        print(f"usage: {sys.argv[0]} host table parquet_file_or_folder [relative_error_bound]")
         sys.exit(1)
 
     flight_client = flight.FlightClient(f"grpc://{sys.argv[1]}")

--- a/Evaluate-ModelarDB-Compression/main.py
+++ b/Evaluate-ModelarDB-Compression/main.py
@@ -278,7 +278,7 @@ def send_sigint_to_process(process):
 if __name__ == "__main__":
     # Ensure the necessary arguments are provided.
     if len(sys.argv) < 2:
-        print(f"usage: {sys.argv[0]} test_data.parquet error_bound*")
+        print(f"usage: {sys.argv[0]} test_data.parquet relative_error_bound*")
         sys.exit(1)
 
     # The script assumes it runs on Linux.

--- a/ModelarDB-Evaluator/src/client.rs
+++ b/ModelarDB-Evaluator/src/client.rs
@@ -87,7 +87,7 @@ impl Client {
                 DataType::Timestamp(TimeUnit::Millisecond, None) => {
                     format!("{} TIMESTAMP", field.name())
                 }
-                DataType::Float32 => format!("{} FIELD({error_bound})", field.name()),
+                DataType::Float32 => format!("{} FIELD({error_bound}%)", field.name()),
                 DataType::Utf8 => format!("{} TAG", field.name()),
                 data_type => Err(FlightError::NotYetImplemented(format!(
                     "Only Timestamp, Float, and String are supported, {data_type} is not."


### PR DESCRIPTION
This PR makes all of the tools explicitly use a relative error bound in preparation for ModelarData/ModelarDB-RS#167. In addition to reviewing the chance, please also double check that all of the tools that creates `FIELD` columns with a non-zero error bound uses a relative error bound for consistency.