### PR TITLE
Added methods to drop, truncate, and get the node type to Apache Arrow Flight Tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# PyCharm files
+.idea/

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -48,7 +48,7 @@ class ModelarDBFlightClient:
         """
         create_table = "CREATE MODEL TABLE" if model_table else "CREATE TABLE"
         sql = f"{create_table} {table_name}({', '.join([f'{column[0]} {column[1]}' for column in columns])})"
-        self.do_action("CommandStatementUpdate", str.encode(sql))
+        self.do_action("CreateTable", str.encode(sql))
 
     def create_test_tables(self) -> None:
         """

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -67,6 +67,14 @@ class ModelarDBFlightClient:
             print(f"{table_name}:")
             print(f"{self.get_schema(table_name)}\n")
 
+    def drop_table(self, table_name: str) -> None:
+        """Drop the table with the given name from the server or manager."""
+        self.do_action("DropTable", str.encode(table_name))
+
+    def truncate_table(self, table_name: str) -> None:
+        """Truncate the table with the given name in the server or manager."""
+        self.do_action("TruncateTable", str.encode(table_name))
+    
 
 def encode_argument(argument: str) -> bytes:
     """Encode the given argument as bytes and prepend the size of the argument as a 2-byte integer."""

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -90,6 +90,11 @@ class ModelarDBFlightClient:
         for table_name in tables:
             self.drop_table(table_name) if operation == "drop" else self.truncate_table(table_name)
 
+    def node_type(self) -> str:
+        """Return the type of the node."""
+        node_type = self.do_action("NodeType", b"")
+        return node_type[0].body.to_pybytes().decode("utf-8")
+
 
 def encode_argument(argument: str) -> bytes:
     """Encode the given argument as bytes and prepend the size of the argument as a 2-byte integer."""

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pyarrow import flight, Schema
 from pyarrow._flight import FlightInfo, ActionType, Result
 
@@ -74,7 +76,20 @@ class ModelarDBFlightClient:
     def truncate_table(self, table_name: str) -> None:
         """Truncate the table with the given name in the server or manager."""
         self.do_action("TruncateTable", str.encode(table_name))
-    
+
+    def clean_up_tables(self, tables: list[str], operation: Literal["drop", "truncate"]) -> None:
+        """
+        Clean up the given tables by either dropping them or truncating them. If no tables are given, all tables
+        are dropped or truncated.
+        """
+        if len(tables) == 0:
+            tables = self.list_table_names()
+
+        print(f"Cleaning up {', '.join(tables)} using {operation}...")
+
+        for table_name in tables:
+            self.drop_table(table_name) if operation == "drop" else self.truncate_table(table_name)
+
 
 def encode_argument(argument: str) -> bytes:
     """Encode the given argument as bytes and prepend the size of the argument as a 2-byte integer."""

--- a/Apache-Arrow-Flight-Tester/manager.py
+++ b/Apache-Arrow-Flight-Tester/manager.py
@@ -55,6 +55,8 @@ class ModelarDBManagerFlightClient(ModelarDBFlightClient):
 
 if __name__ == "__main__":
     manager_client = ModelarDBManagerFlightClient("grpc://127.0.0.1:9998")
+    print(f"Node type: {manager_client.node_type()}\n")
+
     manager_client.create_test_tables()
 
     print(manager_client.initialize_database(["test_table_1"]))

--- a/Apache-Arrow-Flight-Tester/server.py
+++ b/Apache-Arrow-Flight-Tester/server.py
@@ -112,6 +112,7 @@ def create_record_batch(num_rows: int) -> pyarrow.RecordBatch:
 
 if __name__ == "__main__":
     server_client = ModelarDBServerFlightClient("grpc://127.0.0.1:9999")
+    print(f"Node type: {server_client.node_type()}\n")
 
     server_client.create_test_tables()
     server_client.ingest_into_server_and_query_table("test_model_table_1", 10000)

--- a/Apache-Parquet-Loader/main.py
+++ b/Apache-Parquet-Loader/main.py
@@ -29,7 +29,7 @@ def create_model_table(flight_client, table_name, schema, error_bound):
     sql = f"CREATE MODEL TABLE {table_name} ({', '.join(columns)})"
 
     # Execute the CREATE MODEL TABLE command.
-    action = flight.Action("CommandStatementUpdate", str.encode(sql))
+    action = flight.Action("CreateTable", str.encode(sql))
     result = flight_client.do_action(action)
     return list(result)
 

--- a/ModelarDB-Evaluator/src/client.rs
+++ b/ModelarDB-Evaluator/src/client.rs
@@ -98,7 +98,7 @@ impl Client {
         }
 
         let sql = format!("CREATE MODEL TABLE {TABLE_NAME} ({})", columns.join(", "));
-        let action = Action::new("CommandStatementUpdate", sql);
+        let action = Action::new("CreateTable", sql);
         self.flight_client.do_action(action).await?;
 
         Ok(())


### PR DESCRIPTION
This PR adds a few new methods to the Apache Arrow Flight Tester that makes it easy to test `DropTable`, `TruncateTable`, and `NodeType` in both the server and manager.