### PR TITLE
Updated Apache Arrow Flights Testers to use do_get instead of do_action for creating, dropping, and truncating

### DIFF
--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -25,7 +25,7 @@ class ModelarDBFlightClient:
         return response.schema
 
     def do_get(self, ticket: Ticket) -> None:
-        """Execute a SQL statement on the server and print the result."""
+        """Wrapper around the do_get method of the FlightClient class."""
         response = self.flight_client.do_get(ticket)
 
         for batch in response:

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -1,7 +1,8 @@
+import pprint
 from typing import Literal
 
 from pyarrow import flight, Schema
-from pyarrow._flight import FlightInfo, ActionType, Result
+from pyarrow._flight import FlightInfo, ActionType, Result, Ticket
 
 
 class ModelarDBFlightClient:
@@ -22,6 +23,13 @@ class ModelarDBFlightClient:
         response = self.flight_client.get_schema(upload_descriptor)
 
         return response.schema
+
+    def do_get(self, ticket: Ticket) -> None:
+        """Execute a SQL statement on the server and print the result."""
+        response = self.flight_client.do_get(ticket)
+
+        for batch in response:
+            pprint.pprint(batch.data.to_pydict())
 
     def do_action(self, action_type: str, action_body: bytes) -> list[Result]:
         """Wrapper around the do_action method of the FlightClient class."""

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -56,7 +56,8 @@ class ModelarDBFlightClient:
         """
         create_table = "CREATE MODEL TABLE" if model_table else "CREATE TABLE"
         sql = f"{create_table} {table_name}({', '.join([f'{column[0]} {column[1]}' for column in columns])})"
-        self.do_action("CreateTable", str.encode(sql))
+
+        self.do_get(Ticket(sql))
 
     def create_test_tables(self) -> None:
         """
@@ -79,11 +80,11 @@ class ModelarDBFlightClient:
 
     def drop_table(self, table_name: str) -> None:
         """Drop the table with the given name from the server or manager."""
-        self.do_action("DropTable", str.encode(table_name))
+        self.do_get(Ticket(f"DROP TABLE {table_name}"))
 
     def truncate_table(self, table_name: str) -> None:
         """Truncate the table with the given name in the server or manager."""
-        self.do_action("TruncateTable", str.encode(table_name))
+        self.do_get(Ticket(f"TRUNCATE TABLE {table_name}"))
 
     def clean_up_tables(self, tables: list[str], operation: Literal["drop", "truncate"]) -> None:
         """

--- a/Apache-Arrow-Flight-Tester/manager.py
+++ b/Apache-Arrow-Flight-Tester/manager.py
@@ -65,3 +65,5 @@ if __name__ == "__main__":
     print(manager_client.remove_node("grpc://127.0.0.1:9999"))
 
     manager_client.query("SELECT * FROM test_model_table_1 LIMIT 5")
+
+    manager_client.clean_up_tables([], "drop")

--- a/Apache-Arrow-Flight-Tester/server.py
+++ b/Apache-Arrow-Flight-Tester/server.py
@@ -1,4 +1,3 @@
-import pprint
 import time
 from random import randrange
 
@@ -20,13 +19,6 @@ class ModelarDBServerFlightClient(ModelarDBFlightClient):
 
         writer.write(record_batch)
         writer.close()
-
-    def do_get(self, ticket: Ticket) -> None:
-        """Execute a SQL query on the server and print the result."""
-        response = self.flight_client.do_get(ticket)
-
-        for batch in response:
-            pprint.pprint(batch.data.to_pydict())
 
     def collect_metrics(self) -> pd.DataFrame:
         """Collect metrics from the server and return them as a pandas DataFrame."""

--- a/Apache-Arrow-Flight-Tester/server.py
+++ b/Apache-Arrow-Flight-Tester/server.py
@@ -115,3 +115,5 @@ if __name__ == "__main__":
     print("\nCurrent configuration:")
     server_client.update_configuration("compressed_reserved_memory_in_bytes", "10000000")
     print(server_client.get_configuration())
+
+    server_client.clean_up_tables([], "drop")


### PR DESCRIPTION
This PR updates the Apache Arrow Flight Testers after creating, dropping, and truncating tables were moved to `do_get` from `do_action` in https://github.com/ModelarData/ModelarDB-RS/pull/266. 