### PR TITLE
Change create table from do_action to do_get

### DIFF
--- a/Apache-Parquet-Loader/main.py
+++ b/Apache-Parquet-Loader/main.py
@@ -29,8 +29,8 @@ def create_model_table(flight_client, table_name, schema, error_bound):
     sql = f"CREATE MODEL TABLE {table_name} ({', '.join(columns)})"
 
     # Execute the CREATE MODEL TABLE command.
-    action = flight.Action("CreateTable", str.encode(sql))
-    result = flight_client.do_action(action)
+    ticket = flight.Ticket(str.encode(sql))
+    result = flight_client.do_get(ticket)
     return list(result)
 
 


### PR DESCRIPTION
This PR changes how `Apache-Parquet-Loader` creates tables from `do_action()`  to `do_get()`.