### PR TITLE
Add ModelarDB Storage Insights

### DIFF
--- a/ModelarDB-Storage-Insights/main.py
+++ b/ModelarDB-Storage-Insights/main.py
@@ -1,0 +1,194 @@
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from collections import Counter
+
+import pyarrow
+from pyarrow import parquet
+from pyarrow import Table
+
+
+MODEL_TYPE_ID_TO_NAME = ["PMC_Mean", "Swing", "Gorilla"]
+
+
+@dataclass
+class FileResult:
+    file_path: str
+    field_column: int
+    model_types_used: dict[str, int]
+    rust_size_in_bytes: int
+    python_size_in_bytes: int
+    python_size_in_bytes_per_column: dict[str, int]
+
+
+def list_and_process_files(model_table_path: str) -> [FileResult]:
+    file_results = []
+
+    for dirpath, _dirnames, filenames in os.walk(model_table_path):
+        for filename in filenames:
+            if not filename.endswith(".parquet"):
+                continue
+
+            file_path = os.path.join(dirpath, filename)
+            file_result = measure_file_and_its_columns(file_path)
+            file_results.append(file_result)
+
+    return file_results
+
+
+def measure_file_and_its_columns(file_path: str) -> FileResult:
+    table = parquet.read_table(file_path)
+
+    field_column_str = file_path.split(os.sep)[-2]
+    field_column = int(field_column_str[field_column_str.rfind("=") + 1 :])
+
+    rust_size_in_bytes = os.path.getsize(file_path)
+    python_size_in_bytes = write_table(table)
+
+    model_types_used = Counter()
+    python_size_in_bytes_per_column = Counter()
+    for field in table.schema:
+        column = table.column(field.name)
+        if field.name == "model_type_id":
+            for value in column:
+                model_type_name = MODEL_TYPE_ID_TO_NAME[value.as_py()]
+                model_types_used[model_type_name] += 1
+
+        column_schema = pyarrow.schema(pyarrow.struct([field]))
+        column_table = Table.from_arrays([column], schema=column_schema)
+        python_size_in_bytes_per_column[field.name] = write_table(column_table)
+
+    return FileResult(
+        file_path,
+        field_column,
+        model_types_used,
+        rust_size_in_bytes,
+        python_size_in_bytes,
+        python_size_in_bytes_per_column,
+    )
+
+
+def write_table(table: Table) -> int:
+    with tempfile.NamedTemporaryFile() as temp_file_path:
+        parquet.write_table(
+            table,
+            temp_file_path.name,
+            data_page_size=16384,
+            row_group_size=65536,
+            column_encoding="PLAIN",
+            compression="ZSTD",
+            use_dictionary=False,
+            write_statistics=False,
+        )
+        return os.path.getsize(temp_file_path.name)
+
+
+def print_file_results(file_results: list[FileResult]):
+    field_model_types_used = Counter()
+    field_rust_size_in_bytes = 0
+    field_python_size_in_bytes = 0
+    field_size_in_bytes_per_column = Counter()
+
+    total_model_types_used = Counter()
+    total_rust_size_in_bytes = 0
+    total_python_size_in_bytes = 0
+    total_size_in_bytes_per_column = Counter()
+
+    file_results.sort(key=lambda fr: fr.field_column)
+
+    last_field_column = file_results[0].field_column
+    for file_result in file_results:
+        if last_field_column != file_result.field_column:
+            print_total_size_in_bytes(
+                last_field_column,
+                field_model_types_used,
+                field_rust_size_in_bytes,
+                field_python_size_in_bytes,
+                field_size_in_bytes_per_column,
+            )
+            field_model_types_used = Counter()
+            field_rust_size_in_bytes = 0
+            field_python_size_in_bytes = 0
+            field_size_in_bytes_per_column = Counter()
+
+        field_model_types_used.update(file_result.model_types_used)
+        field_rust_size_in_bytes += file_result.rust_size_in_bytes
+        field_python_size_in_bytes += file_result.python_size_in_bytes
+        field_size_in_bytes_per_column.update(
+               file_result.python_size_in_bytes_per_column
+        )
+
+        total_model_types_used.update(file_result.model_types_used)
+        total_rust_size_in_bytes += file_result.rust_size_in_bytes
+        total_python_size_in_bytes += file_result.python_size_in_bytes
+        total_size_in_bytes_per_column.update(
+               file_result.python_size_in_bytes_per_column
+        )
+
+        last_field_column = file_result.field_column
+
+    print_total_size_in_bytes(
+        last_field_column,
+        field_model_types_used,
+        field_rust_size_in_bytes,
+        field_python_size_in_bytes,
+        field_size_in_bytes_per_column,
+    )
+
+    print_total_size_in_bytes(
+        "All",
+        total_model_types_used,
+        total_rust_size_in_bytes,
+        total_python_size_in_bytes,
+        total_size_in_bytes_per_column,
+    )
+
+
+def print_total_size_in_bytes(
+    field_column: int | str,
+    model_types_used: dict[str, int],
+    rust_size_in_bytes: int,
+    python_size_in_bytes: int,
+    size_in_bytes_per_column: dict[str, int],
+):
+    print(f"Field Column: {field_column}")
+    print("------------------------------------------")
+
+    for model_type_name, count in model_types_used.items():
+        print(f"- {model_type_name:<20} {count:>10} Segments")
+    print("------------------------------------------")
+
+    summed_size_in_bytes = 0
+    for column, size in size_in_bytes_per_column.items():
+        print(f"- {column:<25} {bytes_to_mib(size):>10} MiB")
+        summed_size_in_bytes += size
+
+    print("------------------------------------------")
+    print(f"- Summed Size {bytes_to_mib(summed_size_in_bytes):>24} MiB")
+    print(f"- Python Size {bytes_to_mib(python_size_in_bytes):>24} MiB")
+    print(f"- Rust Size {bytes_to_mib(rust_size_in_bytes):>26} MiB")
+    print()
+
+
+def bytes_to_mib(size_in_bytes: int) -> int:
+    return round(size_in_bytes / 1024 / 1024, 2)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"python3 {__file__} data_folder table_name")
+        return
+
+    data_folder = sys.argv[1]
+    model_table = sys.argv[2]
+
+    # TODO: read the name of field columns when the issue is fixed.
+    # Link to issue: https://github.com/apache/arrow/issues/45283
+    model_table_path = data_folder + os.sep + "tables" + os.sep + model_table
+    file_results = list_and_process_files(model_table_path=model_table_path)
+    print_file_results(file_results)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -7,42 +7,42 @@ Utilities for simplifying development and testing:
 - [Apache Arrow Flight server testing script](Apache-Arrow-Flight-Tester/server.py) written in
   [Python 3](https://www.python.org/) to test the different endpoints of the ModelarDB server Apache Arrow Flight API.
 
-- [Apache Parquet loading script](Apache-Parquet-Loader) written in [Python 3](https://www.python.org/) to read Apache 
-  Parquet files with equivalent schemas, create a model table with a matching schema if it does not exist, and load 
+- [Apache Parquet loading script](Apache-Parquet-Loader) written in [Python 3](https://www.python.org/) to read Apache
+  Parquet files with equivalent schemas, create a model table with a matching schema if it does not exist, and load
   their data into the created table.
 
-- [ModelarDB change evaluator script](Evaluate-ModelarDB-Changes) written in [Python 3](https://www.python.org/) to 
+- [ModelarDB change evaluator script](Evaluate-ModelarDB-Changes) written in [Python 3](https://www.python.org/) to
   evaluate what impact a set of changes has on [ModelarDB](https://github.com/ModelarData/ModelarDB-RS) in terms of
-  ingestion time, query processing time, and the amount of storage required. The script automatically computes and 
+  ingestion time, query processing time, and the amount of storage required. The script automatically computes and
   evaluates all possible combinations for the set of changes.
 
-- [ModelarDB compression evaluator script](Evaluate-ModelarDB-Compression) written in [Python 3](https://www.python.org/) 
-  to evaluate how well [ModelarDB](https://github.com/ModelarData/ModelarDB-RS) compresses a data set stored in Apache 
-  Parquet files with the same schema for a set of error bounds. For each error bound the script automatically ingests 
+- [ModelarDB compression evaluator script](Evaluate-ModelarDB-Compression) written in [Python 3](https://www.python.org/)
+  to evaluate how well [ModelarDB](https://github.com/ModelarData/ModelarDB-RS) compresses a data set stored in Apache
+  Parquet files with the same schema for a set of error bounds. For each error bound the script automatically ingests
   the data set and computes metrics that indicate how well ModelarDB compressed the data set.
 
-- [Git Hooks](Git-Hooks) written in different scripting languages to ensure that the state of a repository is correct 
+- [Git Hooks](Git-Hooks) written in different scripting languages to ensure that the state of a repository is correct
   before or after a specific action has been performed.
 
 - [ModelarDB evaluator](ModelarDB-Evaluator) written in [Rust](https://www.rust-lang.org/) to evaluate how well
-  [ModelarDB](https://github.com/ModelarData/ModelarDB-RS) compresses a data set stored in Apache Parquet files with the 
-  same schema for a set of error bounds. For each error bound the script automatically ingests the data set and computes 
+  [ModelarDB](https://github.com/ModelarData/ModelarDB-RS) compresses a data set stored in Apache Parquet files with the
+  same schema for a set of error bounds. For each error bound the script automatically ingests the data set and computes
   metrics that indicate how well ModelarDB compressed the data set.
 
 - [ModelarDB storage insights](ModelarDB-Storage-Insights) written in [Python 3](https://www.python.org/) to extract how
   [ModelarDB](https://github.com/ModelarData/ModelarDB-RS) compresses each field stored in a model table. For a data
-  folder and model table, the script reads the Apache Parquet files and computes which type of models are used and how
-  much space each column in the stored Apache Parquet files uses.
+  folder and model table, the script reads the Apache Parquet files and computes which model types are used and how much
+  space each column in the stored Apache Parquet files uses.
 
-- [MQTT simulator](MQTT-Simulator) written in [Python 3](https://www.python.org/) to simulate the sending of packets 
+- [MQTT simulator](MQTT-Simulator) written in [Python 3](https://www.python.org/) to simulate the sending of packets
   from sensors or devices to a broker. The simulator was originally forked from
   [DamascenoRafael/mqtt-simulator](https://github.com/DamascenoRafael/mqtt-simulator).
 
-- [ModelarDB compression profiler script](Profile-ModelarDB-Compression) written in [Python 3](https://www.python.org/) 
-  to compute how much storage each part of [ModelarDB](https://github.com/ModelarData/ModelarDB-RS)'s compressed format 
-  uses at the logical database, table, and column level when stored in Apache Parquet files ordered by `univariate_id` 
+- [ModelarDB compression profiler script](Profile-ModelarDB-Compression) written in [Python 3](https://www.python.org/)
+  to compute how much storage each part of [ModelarDB](https://github.com/ModelarData/ModelarDB-RS)'s compressed format
+  uses at the logical database, table, and column level when stored in Apache Parquet files ordered by `univariate_id`
   and `start_time` and compressed using Zstandard.
 
 ## License
-Unless otherwise stated, the utilities in this repository are licensed under version 2.0 of the Apache License and a 
+Unless otherwise stated, the utilities in this repository are licensed under version 2.0 of the Apache License and a
 copy of the license is stored in the repository.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Utilities for simplifying development and testing:
   same schema for a set of error bounds. For each error bound the script automatically ingests the data set and computes 
   metrics that indicate how well ModelarDB compressed the data set.
 
+- [ModelarDB storage insights](ModelarDB-Storage-Insights) written in [Python 3](https://www.python.org/) to extract how
+  [ModelarDB](https://github.com/ModelarData/ModelarDB-RS) compresses each field stored in a model table. For a data
+  folder and model table, the script reads the Apache Parquet files and computes which type of models are used and how
+  much space each column in the stored Apache Parquet files uses.
+
 - [MQTT simulator](MQTT-Simulator) written in [Python 3](https://www.python.org/) to simulate the sending of packets 
   from sensors or devices to a broker. The simulator was originally forked from
   [DamascenoRafael/mqtt-simulator](https://github.com/DamascenoRafael/mqtt-simulator).


### PR DESCRIPTION
This PR adds ModelarDB Storage Insights, a Python 3 script that computes how a model table stores time series. Currently, it computes which model types are used for each segment and how much space each column of the Apache Parquet files uses. Both are computed at the field level and table level. As the script cannot decompress the data points, it cannot provide any information at the data point level, such as how many data points are represented by each model type.