### PR TITLE
Add methods to test CreateTable action

### DIFF
--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -187,10 +187,7 @@ class ModelarDBFlightClient:
 
 
 def get_time_series_table_schema() -> pyarrow.Schema:
-    """
-    Return a sample schema for a time series table with one timestamp column, three tag columns,
-    and three field columns.
-    """
+    """Return a schema for a time series table with one timestamp column, three tag columns, and three field columns."""
     return pyarrow.schema([
         ("location", pyarrow.utf8()),
         ("install_year", pyarrow.utf8()),

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -65,9 +65,8 @@ class ModelarDBFlightClient:
 
     def create_test_tables(self) -> None:
         """
-        Create a table and a time series table using the flight client, print the current tables to ensure the created
-        tables are included, and print the schema for the created table and time series table to ensure the tables are
-        created correctly.
+        Create a normal table and a time series table using the flight client, print the current tables to ensure the
+        created tables are included, and print the schema to ensure the tables are created correctly.
         """
         print("Creating test tables...")
 
@@ -120,6 +119,38 @@ class ModelarDBFlightClient:
         table_metadata.time_series_table.CopyFrom(time_series_table_metadata)
 
         self.do_action("CreateTable", table_metadata.SerializeToString())
+
+    def create_test_tables_from_metadata(self):
+        """
+        Create a normal table and a time series table using the CreateTable action, print the current tables to ensure
+        the created tables are included, and print the schema to ensure the tables are created correctly.
+        """
+        print("Creating test tables from metadata...")
+
+        normal_table_schema = pyarrow.schema([
+            ("timestamp", pyarrow.timestamp("us")),
+            ("values", pyarrow.float32()),
+            ("metadata", pyarrow.utf8())
+        ])
+
+        self.create_normal_table_from_metadata("test_table_1", normal_table_schema)
+
+        time_series_table_schema = get_time_series_table_schema()
+
+        absolute = protocol_pb2.TableMetadata.TimeSeriesTableMetadata.ErrorBound.Type.ABSOLUTE
+        error_bounds = [protocol_pb2.TableMetadata.TimeSeriesTableMetadata.ErrorBound(value=0, type=absolute)
+                        for _ in range(len(time_series_table_schema))]
+
+        generated_column_expressions = [b'' for _ in range(len(time_series_table_schema))]
+
+        self.create_time_series_table_from_metadata("test_time_series_table_1", time_series_table_schema,
+                                                    error_bounds, generated_column_expressions)
+
+        print("\nCurrent tables:")
+        for table_name in self.list_table_names():
+            print(f"{table_name}:")
+            print(f"{self.get_schema(table_name)}\n")
+
     def drop_table(self, table_name: str) -> None:
         """Drop the table with the given name from the server or manager."""
         self.do_get(Ticket(f"DROP TABLE {table_name}"))

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -1,6 +1,8 @@
+import pyarrow
 import pprint
-from typing import Literal
 
+from typing import Literal
+from protobuf import protocol_pb2
 from pyarrow import flight, Schema
 from pyarrow._flight import FlightInfo, ActionType, Result, Ticket
 
@@ -91,6 +93,17 @@ class ModelarDBFlightClient:
         for table_name in self.list_table_names():
             print(f"{table_name}:")
             print(f"{self.get_schema(table_name)}\n")
+
+    def create_normal_table_from_metadata(self, table_name: str, schema: pyarrow.Schema) -> None:
+        """Create a normal table using the table name and schema."""
+        normal_table_metadata = protocol_pb2.TableMetadata.NormalTableMetadata()
+        normal_table_metadata.name = table_name
+        normal_table_metadata.schema = schema.serialize().to_pybytes()
+
+        table_metadata = protocol_pb2.TableMetadata()
+        table_metadata.normal_table.CopyFrom(normal_table_metadata)
+
+        self.do_action("CreateTable", table_metadata.SerializeToString())
 
     def drop_table(self, table_name: str) -> None:
         """Drop the table with the given name from the server or manager."""

--- a/Apache-Arrow-Flight-Tester/common.py
+++ b/Apache-Arrow-Flight-Tester/common.py
@@ -138,3 +138,21 @@ class ModelarDBFlightClient:
         """Return the type of the node."""
         node_type = self.do_action("NodeType", b"")
         return node_type[0].body.to_pybytes().decode("utf-8")
+
+
+def get_time_series_table_schema() -> pyarrow.Schema:
+    """
+    Return a sample schema for a time series table with one timestamp column, three tag columns,
+    and three field columns.
+    """
+    return pyarrow.schema(
+        [
+            ("location", pyarrow.utf8()),
+            ("install_year", pyarrow.utf8()),
+            ("model", pyarrow.utf8()),
+            ("timestamp", pyarrow.timestamp("us")),
+            ("power_output", pyarrow.float32()),
+            ("wind_speed", pyarrow.float32()),
+            ("temperature", pyarrow.float32()),
+        ]
+    )

--- a/Apache-Arrow-Flight-Tester/manager.py
+++ b/Apache-Arrow-Flight-Tester/manager.py
@@ -9,21 +9,6 @@ from server import ModelarDBServerFlightClient
 class ModelarDBManagerFlightClient(ModelarDBFlightClient):
     """Functionality for interacting with a ModelarDB manager using Apache Arrow Flight."""
 
-    def initialize_database(self, existing_tables: list[str]) -> protocol_pb2.TableMetadata:
-        """
-        Retrieve the table metadata required to initialize the database with the tables that are not included in the
-        given list of tables. Throws an error if a table in the given list does not exist in the database.
-        """
-        database_metadata = protocol_pb2.DatabaseMetadata()
-        database_metadata.table_names.extend(existing_tables)
-
-        response = self.do_action("InitializeDatabase", database_metadata.SerializeToString())
-
-        table_metadata = protocol_pb2.TableMetadata()
-        table_metadata.ParseFromString(response[0].body.to_pybytes())
-
-        return table_metadata
-
     def register_node(self, node_url: str,
                       node_mode: protocol_pb2.NodeMetadata.ServerMode) -> protocol_pb2.ManagerMetadata:
         """Register a node with the given URL and mode in the manager."""
@@ -67,8 +52,6 @@ if __name__ == "__main__":
     print(f"Node type: {manager_client.node_type()}\n")
 
     manager_client.create_test_tables()
-
-    print(manager_client.initialize_database(["test_table_1"]))
 
     print(manager_client.register_node("grpc://127.0.0.1:9999", protocol_pb2.NodeMetadata.ServerMode.EDGE))
     print(manager_client.remove_node("grpc://127.0.0.1:9999"))

--- a/Apache-Arrow-Flight-Tester/manager.py
+++ b/Apache-Arrow-Flight-Tester/manager.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     manager_client = ModelarDBManagerFlightClient("grpc://127.0.0.1:9998")
     print(f"Node type: {manager_client.node_type()}\n")
 
-    manager_client.create_test_tables()
+    manager_client.create_test_tables_from_metadata()
 
     print(manager_client.register_node("grpc://127.0.0.1:9999", protocol_pb2.NodeMetadata.ServerMode.EDGE))
     print(manager_client.remove_node("grpc://127.0.0.1:9999"))

--- a/Apache-Arrow-Flight-Tester/protobuf/protocol.proto
+++ b/Apache-Arrow-Flight-Tester/protobuf/protocol.proto
@@ -58,7 +58,7 @@ message NodeMetadata {
   ServerMode server_mode = 2;
 }
 
-// Metadata for a normal table or a time series tables.
+// Metadata for a normal table or a time series table.
 message TableMetadata {
   // Metadata for a normal table, including its name and schema.
   message NormalTableMetadata {

--- a/Apache-Arrow-Flight-Tester/protobuf/protocol.proto
+++ b/Apache-Arrow-Flight-Tester/protobuf/protocol.proto
@@ -58,7 +58,7 @@ message NodeMetadata {
   ServerMode server_mode = 2;
 }
 
-// Metadata for multiple normal tables and time series tables.
+// Metadata for a normal table or a time series tables.
 message TableMetadata {
   // Metadata for a normal table, including its name and schema.
   message NormalTableMetadata {
@@ -83,11 +83,11 @@ message TableMetadata {
     repeated bytes generated_column_expressions = 4;
   }
 
-  // Normal tables included in the table metadata.
-  repeated NormalTableMetadata normal_tables = 1;
-
-  // Time series tables included in the table metadata.
-  repeated TimeSeriesTableMetadata time_series_tables = 2;
+  // Either a normal table or a time series table.
+  oneof table_metadata {
+    NormalTableMetadata normal_table = 1;
+    TimeSeriesTableMetadata time_series_table = 2;
+  }
 }
 
 // Configuration of a ModelarDB node.
@@ -136,10 +136,4 @@ message UpdateConfiguration {
 
   // New value for the setting.
   optional uint64 new_value = 2;
-}
-
-// Metadata for a ModelarDB database instance.
-message DatabaseMetadata {
-  // Names of the tables in the database.
-  repeated string table_names = 1;
 }

--- a/Apache-Arrow-Flight-Tester/protobuf/protocol_pb2.py
+++ b/Apache-Arrow-Flight-Tester/protobuf/protocol_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eprotocol.proto\x12\x19modelardb.flight.protocol\"\xb1\x03\n\x0fManagerMetadata\x12\x0b\n\x03key\x18\x01 \x01(\t\x12V\n\x10s3_configuration\x18\x02 \x01(\x0b\x32:.modelardb.flight.protocol.ManagerMetadata.S3ConfigurationH\x00\x12\\\n\x13\x61zure_configuration\x18\x03 \x01(\x0b\x32=.modelardb.flight.protocol.ManagerMetadata.AzureConfigurationH\x00\x1aj\n\x0fS3Configuration\x12\x10\n\x08\x65ndpoint\x18\x01 \x01(\t\x12\x13\n\x0b\x62ucket_name\x18\x02 \x01(\t\x12\x15\n\raccess_key_id\x18\x03 \x01(\t\x12\x19\n\x11secret_access_key\x18\x04 \x01(\t\x1aV\n\x12\x41zureConfiguration\x12\x14\n\x0c\x61\x63\x63ount_name\x18\x01 \x01(\t\x12\x12\n\naccess_key\x18\x02 \x01(\t\x12\x16\n\x0e\x63ontainer_name\x18\x03 \x01(\tB\x17\n\x15storage_configuration\"\x87\x01\n\x0cNodeMetadata\x12\x0b\n\x03url\x18\x01 \x01(\t\x12G\n\x0bserver_mode\x18\x02 \x01(\x0e\x32\x32.modelardb.flight.protocol.NodeMetadata.ServerMode\"!\n\nServerMode\x12\t\n\x05\x43LOUD\x10\x00\x12\x08\n\x04\x45\x44GE\x10\x01\"\xdc\x04\n\rTableMetadata\x12S\n\rnormal_tables\x18\x01 \x03(\x0b\x32<.modelardb.flight.protocol.TableMetadata.NormalTableMetadata\x12\\\n\x12time_series_tables\x18\x02 \x03(\x0b\x32@.modelardb.flight.protocol.TableMetadata.TimeSeriesTableMetadata\x1a\x33\n\x13NormalTableMetadata\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06schema\x18\x02 \x01(\x0c\x1a\xe2\x02\n\x17TimeSeriesTableMetadata\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06schema\x18\x02 \x01(\x0c\x12\x61\n\x0c\x65rror_bounds\x18\x03 \x03(\x0b\x32K.modelardb.flight.protocol.TableMetadata.TimeSeriesTableMetadata.ErrorBound\x12$\n\x1cgenerated_column_expressions\x18\x04 \x03(\x0c\x1a\x9f\x01\n\nErrorBound\x12^\n\x04type\x18\x01 \x01(\x0e\x32P.modelardb.flight.protocol.TableMetadata.TimeSeriesTableMetadata.ErrorBound.Type\x12\r\n\x05value\x18\x02 \x01(\x02\"\"\n\x04Type\x12\x0c\n\x08\x41\x42SOLUTE\x10\x00\x12\x0c\n\x08RELATIVE\x10\x01\"\x9f\x03\n\rConfiguration\x12-\n%multivariate_reserved_memory_in_bytes\x18\x01 \x01(\x04\x12-\n%uncompressed_reserved_memory_in_bytes\x18\x02 \x01(\x04\x12+\n#compressed_reserved_memory_in_bytes\x18\x03 \x01(\x04\x12)\n\x1ctransfer_batch_size_in_bytes\x18\x04 \x01(\x04H\x00\x88\x01\x01\x12%\n\x18transfer_time_in_seconds\x18\x05 \x01(\x04H\x01\x88\x01\x01\x12#\n\x1bretention_period_in_seconds\x18\x06 \x01(\x04\x12\x19\n\x11ingestion_threads\x18\x07 \x01(\r\x12\x1b\n\x13\x63ompression_threads\x18\x08 \x01(\r\x12\x16\n\x0ewriter_threads\x18\t \x01(\rB\x1f\n\x1d_transfer_batch_size_in_bytesB\x1b\n\x19_transfer_time_in_seconds\"\xf0\x02\n\x13UpdateConfiguration\x12G\n\x07setting\x18\x01 \x01(\x0e\x32\x36.modelardb.flight.protocol.UpdateConfiguration.Setting\x12\x16\n\tnew_value\x18\x02 \x01(\x04H\x00\x88\x01\x01\"\xe9\x01\n\x07Setting\x12)\n%MULTIVARIATE_RESERVED_MEMORY_IN_BYTES\x10\x00\x12)\n%UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES\x10\x01\x12\'\n#COMPRESSED_RESERVED_MEMORY_IN_BYTES\x10\x02\x12 \n\x1cTRANSFER_BATCH_SIZE_IN_BYTES\x10\x03\x12\x1c\n\x18TRANSFER_TIME_IN_SECONDS\x10\x04\x12\x1f\n\x1bRETENTION_PERIOD_IN_SECONDS\x10\x05\x42\x0c\n\n_new_value\"\'\n\x10\x44\x61tabaseMetadata\x12\x13\n\x0btable_names\x18\x01 \x03(\tb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0eprotocol.proto\x12\x19modelardb.flight.protocol\"\xb1\x03\n\x0fManagerMetadata\x12\x0b\n\x03key\x18\x01 \x01(\t\x12V\n\x10s3_configuration\x18\x02 \x01(\x0b\x32:.modelardb.flight.protocol.ManagerMetadata.S3ConfigurationH\x00\x12\\\n\x13\x61zure_configuration\x18\x03 \x01(\x0b\x32=.modelardb.flight.protocol.ManagerMetadata.AzureConfigurationH\x00\x1aj\n\x0fS3Configuration\x12\x10\n\x08\x65ndpoint\x18\x01 \x01(\t\x12\x13\n\x0b\x62ucket_name\x18\x02 \x01(\t\x12\x15\n\raccess_key_id\x18\x03 \x01(\t\x12\x19\n\x11secret_access_key\x18\x04 \x01(\t\x1aV\n\x12\x41zureConfiguration\x12\x14\n\x0c\x61\x63\x63ount_name\x18\x01 \x01(\t\x12\x12\n\naccess_key\x18\x02 \x01(\t\x12\x16\n\x0e\x63ontainer_name\x18\x03 \x01(\tB\x17\n\x15storage_configuration\"\x87\x01\n\x0cNodeMetadata\x12\x0b\n\x03url\x18\x01 \x01(\t\x12G\n\x0bserver_mode\x18\x02 \x01(\x0e\x32\x32.modelardb.flight.protocol.NodeMetadata.ServerMode\"!\n\nServerMode\x12\t\n\x05\x43LOUD\x10\x00\x12\x08\n\x04\x45\x44GE\x10\x01\"\xf0\x04\n\rTableMetadata\x12T\n\x0cnormal_table\x18\x01 \x01(\x0b\x32<.modelardb.flight.protocol.TableMetadata.NormalTableMetadataH\x00\x12]\n\x11time_series_table\x18\x02 \x01(\x0b\x32@.modelardb.flight.protocol.TableMetadata.TimeSeriesTableMetadataH\x00\x1a\x33\n\x13NormalTableMetadata\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06schema\x18\x02 \x01(\x0c\x1a\xe2\x02\n\x17TimeSeriesTableMetadata\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0e\n\x06schema\x18\x02 \x01(\x0c\x12\x61\n\x0c\x65rror_bounds\x18\x03 \x03(\x0b\x32K.modelardb.flight.protocol.TableMetadata.TimeSeriesTableMetadata.ErrorBound\x12$\n\x1cgenerated_column_expressions\x18\x04 \x03(\x0c\x1a\x9f\x01\n\nErrorBound\x12^\n\x04type\x18\x01 \x01(\x0e\x32P.modelardb.flight.protocol.TableMetadata.TimeSeriesTableMetadata.ErrorBound.Type\x12\r\n\x05value\x18\x02 \x01(\x02\"\"\n\x04Type\x12\x0c\n\x08\x41\x42SOLUTE\x10\x00\x12\x0c\n\x08RELATIVE\x10\x01\x42\x10\n\x0etable_metadata\"\x9f\x03\n\rConfiguration\x12-\n%multivariate_reserved_memory_in_bytes\x18\x01 \x01(\x04\x12-\n%uncompressed_reserved_memory_in_bytes\x18\x02 \x01(\x04\x12+\n#compressed_reserved_memory_in_bytes\x18\x03 \x01(\x04\x12)\n\x1ctransfer_batch_size_in_bytes\x18\x04 \x01(\x04H\x00\x88\x01\x01\x12%\n\x18transfer_time_in_seconds\x18\x05 \x01(\x04H\x01\x88\x01\x01\x12#\n\x1bretention_period_in_seconds\x18\x06 \x01(\x04\x12\x19\n\x11ingestion_threads\x18\x07 \x01(\r\x12\x1b\n\x13\x63ompression_threads\x18\x08 \x01(\r\x12\x16\n\x0ewriter_threads\x18\t \x01(\rB\x1f\n\x1d_transfer_batch_size_in_bytesB\x1b\n\x19_transfer_time_in_seconds\"\xf0\x02\n\x13UpdateConfiguration\x12G\n\x07setting\x18\x01 \x01(\x0e\x32\x36.modelardb.flight.protocol.UpdateConfiguration.Setting\x12\x16\n\tnew_value\x18\x02 \x01(\x04H\x00\x88\x01\x01\"\xe9\x01\n\x07Setting\x12)\n%MULTIVARIATE_RESERVED_MEMORY_IN_BYTES\x10\x00\x12)\n%UNCOMPRESSED_RESERVED_MEMORY_IN_BYTES\x10\x01\x12\'\n#COMPRESSED_RESERVED_MEMORY_IN_BYTES\x10\x02\x12 \n\x1cTRANSFER_BATCH_SIZE_IN_BYTES\x10\x03\x12\x1c\n\x18TRANSFER_TIME_IN_SECONDS\x10\x04\x12\x1f\n\x1bRETENTION_PERIOD_IN_SECONDS\x10\x05\x42\x0c\n\n_new_valueb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -42,21 +42,19 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_NODEMETADATA_SERVERMODE']._serialized_start=584
   _globals['_NODEMETADATA_SERVERMODE']._serialized_end=617
   _globals['_TABLEMETADATA']._serialized_start=620
-  _globals['_TABLEMETADATA']._serialized_end=1224
-  _globals['_TABLEMETADATA_NORMALTABLEMETADATA']._serialized_start=816
-  _globals['_TABLEMETADATA_NORMALTABLEMETADATA']._serialized_end=867
-  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA']._serialized_start=870
-  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA']._serialized_end=1224
-  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA_ERRORBOUND']._serialized_start=1065
-  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA_ERRORBOUND']._serialized_end=1224
-  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA_ERRORBOUND_TYPE']._serialized_start=1190
-  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA_ERRORBOUND_TYPE']._serialized_end=1224
-  _globals['_CONFIGURATION']._serialized_start=1227
-  _globals['_CONFIGURATION']._serialized_end=1642
-  _globals['_UPDATECONFIGURATION']._serialized_start=1645
-  _globals['_UPDATECONFIGURATION']._serialized_end=2013
-  _globals['_UPDATECONFIGURATION_SETTING']._serialized_start=1766
-  _globals['_UPDATECONFIGURATION_SETTING']._serialized_end=1999
-  _globals['_DATABASEMETADATA']._serialized_start=2015
-  _globals['_DATABASEMETADATA']._serialized_end=2054
+  _globals['_TABLEMETADATA']._serialized_end=1244
+  _globals['_TABLEMETADATA_NORMALTABLEMETADATA']._serialized_start=818
+  _globals['_TABLEMETADATA_NORMALTABLEMETADATA']._serialized_end=869
+  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA']._serialized_start=872
+  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA']._serialized_end=1226
+  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA_ERRORBOUND']._serialized_start=1067
+  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA_ERRORBOUND']._serialized_end=1226
+  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA_ERRORBOUND_TYPE']._serialized_start=1192
+  _globals['_TABLEMETADATA_TIMESERIESTABLEMETADATA_ERRORBOUND_TYPE']._serialized_end=1226
+  _globals['_CONFIGURATION']._serialized_start=1247
+  _globals['_CONFIGURATION']._serialized_end=1662
+  _globals['_UPDATECONFIGURATION']._serialized_start=1665
+  _globals['_UPDATECONFIGURATION']._serialized_end=2033
+  _globals['_UPDATECONFIGURATION_SETTING']._serialized_start=1786
+  _globals['_UPDATECONFIGURATION_SETTING']._serialized_end=2019
 # @@protoc_insertion_point(module_scope)

--- a/Apache-Arrow-Flight-Tester/protobuf/protocol_pb2.pyi
+++ b/Apache-Arrow-Flight-Tester/protobuf/protocol_pb2.pyi
@@ -52,7 +52,7 @@ class NodeMetadata(_message.Message):
     def __init__(self, url: _Optional[str] = ..., server_mode: _Optional[_Union[NodeMetadata.ServerMode, str]] = ...) -> None: ...
 
 class TableMetadata(_message.Message):
-    __slots__ = ("normal_tables", "time_series_tables")
+    __slots__ = ("normal_table", "time_series_table")
     class NormalTableMetadata(_message.Message):
         __slots__ = ("name", "schema")
         NAME_FIELD_NUMBER: _ClassVar[int]
@@ -84,11 +84,11 @@ class TableMetadata(_message.Message):
         error_bounds: _containers.RepeatedCompositeFieldContainer[TableMetadata.TimeSeriesTableMetadata.ErrorBound]
         generated_column_expressions: _containers.RepeatedScalarFieldContainer[bytes]
         def __init__(self, name: _Optional[str] = ..., schema: _Optional[bytes] = ..., error_bounds: _Optional[_Iterable[_Union[TableMetadata.TimeSeriesTableMetadata.ErrorBound, _Mapping]]] = ..., generated_column_expressions: _Optional[_Iterable[bytes]] = ...) -> None: ...
-    NORMAL_TABLES_FIELD_NUMBER: _ClassVar[int]
-    TIME_SERIES_TABLES_FIELD_NUMBER: _ClassVar[int]
-    normal_tables: _containers.RepeatedCompositeFieldContainer[TableMetadata.NormalTableMetadata]
-    time_series_tables: _containers.RepeatedCompositeFieldContainer[TableMetadata.TimeSeriesTableMetadata]
-    def __init__(self, normal_tables: _Optional[_Iterable[_Union[TableMetadata.NormalTableMetadata, _Mapping]]] = ..., time_series_tables: _Optional[_Iterable[_Union[TableMetadata.TimeSeriesTableMetadata, _Mapping]]] = ...) -> None: ...
+    NORMAL_TABLE_FIELD_NUMBER: _ClassVar[int]
+    TIME_SERIES_TABLE_FIELD_NUMBER: _ClassVar[int]
+    normal_table: TableMetadata.NormalTableMetadata
+    time_series_table: TableMetadata.TimeSeriesTableMetadata
+    def __init__(self, normal_table: _Optional[_Union[TableMetadata.NormalTableMetadata, _Mapping]] = ..., time_series_table: _Optional[_Union[TableMetadata.TimeSeriesTableMetadata, _Mapping]] = ...) -> None: ...
 
 class Configuration(_message.Message):
     __slots__ = ("multivariate_reserved_memory_in_bytes", "uncompressed_reserved_memory_in_bytes", "compressed_reserved_memory_in_bytes", "transfer_batch_size_in_bytes", "transfer_time_in_seconds", "retention_period_in_seconds", "ingestion_threads", "compression_threads", "writer_threads")
@@ -133,9 +133,3 @@ class UpdateConfiguration(_message.Message):
     setting: UpdateConfiguration.Setting
     new_value: int
     def __init__(self, setting: _Optional[_Union[UpdateConfiguration.Setting, str]] = ..., new_value: _Optional[int] = ...) -> None: ...
-
-class DatabaseMetadata(_message.Message):
-    __slots__ = ("table_names",)
-    TABLE_NAMES_FIELD_NUMBER: _ClassVar[int]
-    table_names: _containers.RepeatedScalarFieldContainer[str]
-    def __init__(self, table_names: _Optional[_Iterable[str]] = ...) -> None: ...

--- a/Apache-Arrow-Flight-Tester/server.py
+++ b/Apache-Arrow-Flight-Tester/server.py
@@ -65,7 +65,7 @@ def create_record_batch(num_rows: int) -> pyarrow.RecordBatch:
     install_year = ["2021" if i % 2 == 0 else "2022" for i in range(num_rows)]
     model = ["w72" if i % 2 == 0 else "w73" for i in range(num_rows)]
 
-    timestamp = [round(time.time() * 1000000) + (i * 1000) for i in range(num_rows)]
+    timestamp = [round(time.time() * 1000000) + (i * 1000000) for i in range(num_rows)]
     power_output = [float(randrange(0, 30)) for _ in range(num_rows)]
     wind_speed = [float(randrange(50, 100)) for _ in range(num_rows)]
     temperature = [float(randrange(0, 40)) for _ in range(num_rows)]

--- a/Apache-Arrow-Flight-Tester/server.py
+++ b/Apache-Arrow-Flight-Tester/server.py
@@ -5,7 +5,7 @@ import pyarrow
 from pyarrow import flight
 from pyarrow._flight import Result, Ticket
 
-from common import ModelarDBFlightClient
+from common import ModelarDBFlightClient, get_time_series_table_schema
 from protobuf import protocol_pb2
 
 
@@ -59,23 +59,13 @@ def create_record_batch(num_rows: int) -> pyarrow.RecordBatch:
     Create a record batch with num_rows rows of randomly generated data for a table with one timestamp column,
     three tag columns, and three field columns.
     """
-    schema = pyarrow.schema(
-        [
-            ("location", pyarrow.utf8()),
-            ("install_year", pyarrow.utf8()),
-            ("model", pyarrow.utf8()),
-            ("timestamp", pyarrow.timestamp("ms")),
-            ("power_output", pyarrow.float32()),
-            ("wind_speed", pyarrow.float32()),
-            ("temperature", pyarrow.float32()),
-        ]
-    )
+    schema = get_time_series_table_schema()
 
     location = ["aalborg" if i % 2 == 0 else "nibe" for i in range(num_rows)]
     install_year = ["2021" if i % 2 == 0 else "2022" for i in range(num_rows)]
     model = ["w72" if i % 2 == 0 else "w73" for i in range(num_rows)]
 
-    timestamp = [round(time.time() * 1000) + (i * 1000) for i in range(num_rows)]
+    timestamp = [round(time.time() * 1000000) + (i * 1000) for i in range(num_rows)]
     power_output = [float(randrange(0, 30)) for _ in range(num_rows)]
     wind_speed = [float(randrange(50, 100)) for _ in range(num_rows)]
     temperature = [float(randrange(0, 40)) for _ in range(num_rows)]


### PR DESCRIPTION
This PR updates the Apache Arrow Flight testers to match the changes made in https://github.com/ModelarData/ModelarDB-RS/pull/346. The PR adds new methods to make it possible to test the `CreateTable` action for both the server and manager and also removes the method that was used to test the `InitializeDatabase` endpoint. 

**Note that this PR should not be merged before https://github.com/ModelarData/ModelarDB-RS/pull/346 is merged.**