### PR TITLE
Change timestamp column's type for the loader script

### DIFF
--- a/Apache-Parquet-Loader/main.py
+++ b/Apache-Parquet-Loader/main.py
@@ -5,7 +5,7 @@ import glob
 import pyarrow
 from pyarrow import parquet
 from pyarrow import flight
-import pyarrow.compute as compute
+from pyarrow import compute
 
 
 # Helper Functions.


### PR DESCRIPTION
Previously, this script used to convert the timestamp column to milliseconds. This commit ensures:
* matches the current version of ModelarDB where timestamps are read in microseconds. 
* not only schema is casted, but also timestamps are casted to microseconds. This is important since we had some experience with loading the wrong timestamps to ModelarDB.